### PR TITLE
Fix issue with creating new groups from pre-existing moving groups.

### DIFF
--- a/Assets/Scripts/EntitySelector.cs
+++ b/Assets/Scripts/EntitySelector.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class EntitySelector : MonoBehaviour
@@ -39,16 +40,9 @@ public class EntitySelector : MonoBehaviour
             Ray ray = cam.ScreenPointToRay(Input.mousePosition);
 
             RaycastHit hit;
-            if (Physics.Raycast(ray, out hit, camScript.distanceFromPlanetSurface + planetScript.radius, LayerMask.GetMask("Planets"))) 
+            if (Physics.Raycast(ray, out hit, camScript.distanceFromPlanetSurface + planetScript.radius, LayerMask.GetMask("Planets")))
             {
-                var selectedGroups = new List<UnitGroup>();
-                foreach (var group in Game.groups)
-                {
-                    if (group.IsSelected()) 
-                    {
-                        selectedGroups.Add(group);
-                    }
-                }
+                var selectedGroups = Game.groups.Where(group => group.IsSelected()).ToList();
 
                 if (selectedGroups.Count == 1)
                 {
@@ -58,7 +52,9 @@ public class EntitySelector : MonoBehaviour
                 {
                     // Flawed logic, does not work for some reason.
 
-                    /*var unitsForNewGroup = new List<GameObject>();
+                    // Debug.Log(Game.groups.Count);
+
+                    var unitsForNewGroup = new List<GameObject>();
 
                     foreach (var group in selectedGroups)
                     {
@@ -67,11 +63,12 @@ public class EntitySelector : MonoBehaviour
                         foreach (var unitGo in group.units)
                         {
                             var unit = unitGo.GetComponent<Unit>();
-                            if (unit.selected) 
-                            {
-                                unit.group = null;
-                                unitsForNewGroup.Add(unitGo);
-                            }
+
+                            if (!unit.selected)
+                                continue;
+
+                            unit.LeaveCurrentGroup();
+                            unitsForNewGroup.Add(unitGo);
                         }
 
                         group.RemoveGroupIfMemberCountLow();
@@ -79,7 +76,7 @@ public class EntitySelector : MonoBehaviour
 
                     var newGroup = new UnitGroup(unitsForNewGroup, planet.transform);
                     Game.groups.Add(newGroup);
-                    newGroup.MoveToTarget(hit.point);*/
+                    newGroup.MoveToTarget(hit.point);
                 }
             }
         }

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -89,7 +89,7 @@ public class Unit : MonoBehaviour
             transform.rotation = Quaternion.LookRotation(forward, gravityUp);
 
         // Snap back to planets surface
-        this.transform.position = gravityUp * (planetRadius + 1);
+        transform.position = gravityUp * (planetRadius + 1);
     }
 
     /*
@@ -105,7 +105,7 @@ public class Unit : MonoBehaviour
 
         for (int i = 0; i < numColliders; i++)
         {
-            var agentA = this.transform.position;
+            var agentA = transform.position;
             var agentB = hitColliders[i].transform.position;
 
             var unit = hitColliders[i].GetComponent<Unit>();
@@ -124,7 +124,7 @@ public class Unit : MonoBehaviour
 
                 // Separate the agents from each other
                 var separationForce = maxDist - curDist;
-                this.transform.position += dir * separationForce * Time.deltaTime;
+                transform.position += dir * separationForce * Time.deltaTime;
             }
         }
     }
@@ -145,11 +145,12 @@ public class Unit : MonoBehaviour
     /*
      * Leave current group if any.
      */
-    public void LeaveCurrentGroup() 
-    {
-        if (group != null)
-            group.units.Remove(this.gameObject);
-    }
+    public void LeaveCurrentGroup() =>
+        group?.RemoveUnit(this);
 
-    public void SetMaxSpeed(float value) => speed = value;
+    public void Idle() =>
+        unitTask = UnitTask.Idle;
+
+    public void SetMaxSpeed(float value) =>
+        speed = value;
 }

--- a/Assets/Scripts/Utils.cs
+++ b/Assets/Scripts/Utils.cs
@@ -5,8 +5,6 @@ using UnityEngine;
 public static class Utils
 {
     // Extension method
-    public static float Remap(this float value, float from1, float to1, float from2, float to2)
-    {
-        return (value - from1) / (to1 - from1) * (to2 - from2) + from2;
-    }
+    public static float Remap(this float value, float from1, float to1, float from2, float to2) =>
+        (value - from1) / (to1 - from1) * (to2 - from2) + from2;
 }


### PR DESCRIPTION
This PR solves a bug where unknown behaviour is experienced when the player attempts to create and issue a movement command to a group of units who originate from multiple pre-existing groups that are moving.

Minor readability improvements also included.

There is still occasional weird behaviour with lone units wandering off, presumably caused by another issue, but the main problem has been fixed in this PR.